### PR TITLE
Cubeformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# example-package
-✖
+# Selective Attention Transformer
+
+An alternative transformer attention layer.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # example-package
+✖

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -2,7 +2,7 @@
 model:
   d_model: 32
   num_heads: 2
-  mha_type: cubic
+  mha_type: selective
   num_layers: 3
 
 dataset:

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -2,6 +2,7 @@
 model:
   d_model: 32
   num_heads: 2
+  mha_type: cubic
   num_layers: 3
 
 dataset:

--- a/configs/template.py
+++ b/configs/template.py
@@ -17,6 +17,7 @@ class ShakespearDatasetConfig:
 class DecoderOnlyTransformerConfig:
     d_model: int
     num_heads: int
+    mha_type: str
     num_layers: int
 
 

--- a/configs/template.py
+++ b/configs/template.py
@@ -14,7 +14,7 @@ class ShakespearDatasetConfig:
 
 
 @dataclass
-class DecoderOnlyTransformerConfig:
+class DecoderTransformerConfig:
     d_model: int
     num_heads: int
     mha_type: str
@@ -31,5 +31,5 @@ class TrainerConfig:
 @dataclass
 class MainConfig:
     dataset: ShakespearDatasetConfig
-    model: DecoderOnlyTransformerConfig
+    model: DecoderTransformerConfig
     trainer: TrainerConfig

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ def main(dict_config: DictConfig):
         dataset.vocab_size,
         config.model.d_model,
         config.model.num_heads,
+        config.model.mha_type,
         config.model.num_layers,
         dataset.vocab_size,
         sk,

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import jax.random as random
 import src.trainer as trainer
 import wandb
 from configs.template import (
-    DecoderOnlyTransformerConfig,
+    DecoderTransformerConfig,
     MainConfig,
     ShakespearDatasetConfig,
     TrainerConfig,
@@ -11,7 +11,7 @@ from configs.template import (
 from hydra.core.config_store import ConfigStore
 from omegaconf import DictConfig, OmegaConf
 from src.datasets import ShakespearDataset
-from src.model import DecoderOnlyTransformer
+from src.model import DecoderTransformer
 
 cs = ConfigStore.instance()
 cs.store(name="main-config", node=MainConfig)
@@ -21,7 +21,7 @@ cs.store(name="main-config", node=MainConfig)
 def main(dict_config: DictConfig):
     config = MainConfig(
         dataset=ShakespearDatasetConfig(**dict_config.dataset),
-        model=DecoderOnlyTransformerConfig(**dict_config.model),
+        model=DecoderTransformerConfig(**dict_config.model),
         trainer=TrainerConfig(**dict_config.trainer),
     )
     dataset = ShakespearDataset.from_file(
@@ -30,7 +30,7 @@ def main(dict_config: DictConfig):
     key = random.key(config.trainer.seed)
 
     key, sk = random.split(key)
-    model = DecoderOnlyTransformer(
+    model = DecoderTransformer(
         dataset.vocab_size,
         config.model.d_model,
         config.model.num_heads,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "Cubeformer"
+name = "Selective Attention Transformer"
 version = "0.0.1"
 description = "Why not?"
 authors = [

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,1 +1,1 @@
-from .decoder_only import DecoderOnlyTransformer  # noqa: F401
+from .decoder_only import DecoderTransformer  # noqa: F401

--- a/src/model/mha.py
+++ b/src/model/mha.py
@@ -27,6 +27,21 @@ def qkv_attention(
     return attn_result
 
 
+@jax.jit
+@jaxtyped(typechecker=beartype)
+def qkv_cubic_attention(
+    q: Float[Array, "q_seq d_model"],
+    k: Float[Array, "q_seq kv_seq d_model"],
+    v: Float[Array, "q_seq kv_seq d_model"],
+    mask: Optional[Bool[Array, "q_seq kv_seq"]] = None,
+) -> Float[Array, "q_seq d_model"]:
+    q = rearrange(q, "s d -> s 1 d")
+    mask = rearrange(mask, "s t -> s 1 t")
+    attn_result = jax.vmap(qkv_attention)(q, k, v, mask)
+    attn_result = rearrange(attn_result, "s 1 d -> s d")
+    return attn_result
+
+
 class MultiheadAttention(eqx.Module):
     project_q: nn.Linear
     project_k: nn.Linear
@@ -52,10 +67,12 @@ class MultiheadAttention(eqx.Module):
         v: Float[Array, "seq_len d_model"],
         mask: Bool[Array, "seq_len seq_len"],
     ) -> Float[Array, "seq_len d_model"]:
+        # Project q k and v.
         q = jax.vmap(self.project_q)(q)
         k = jax.vmap(self.project_k)(k)
         v = jax.vmap(self.project_v)(v)
 
+        # Separate heads.
         q_heads = rearrange(q, "s (n d) -> n s d", n=self.num_heads)
         k_heads = rearrange(k, "s (n d) -> n s d", n=self.num_heads)
         v_heads = rearrange(v, "s (n d) -> n s d", n=self.num_heads)
@@ -63,5 +80,53 @@ class MultiheadAttention(eqx.Module):
         # Do not vmap the mask. The mask is the same accross all heads.
         qkv_attention_heads = jax.vmap(qkv_attention, in_axes=(0, 0, 0, None))
         attn_result = qkv_attention_heads(q_heads, k_heads, v_heads, mask)
+        attn_result = rearrange(attn_result, "n s d -> s (n d)")
+        return attn_result
+
+
+class MultiheadCubeAttention(eqx.Module):
+    project_q: nn.Linear
+    hyper_k: nn.Linear
+    hyper_v: nn.Linear
+    num_heads: int
+
+    def __init__(self, num_heads: int, d_model: int, key: random.PRNGKey):
+        super().__init__()
+        assert d_model % num_heads == 0
+        self.num_heads = num_heads
+
+        sk = random.split(key, 3)
+        self.project_q = nn.Linear(d_model, d_model, use_bias=False, key=sk[0])
+        self.hyper_k = nn.Linear(d_model, d_model * d_model, use_bias=False, key=sk[1])
+        self.hyper_v = nn.Linear(d_model, d_model * d_model, use_bias=False, key=sk[2])
+
+    def __call__(
+        self,
+        q: Float[Array, "seq_len d_model"],
+        k: Float[Array, "seq_len d_model"],
+        v: Float[Array, "seq_len d_model"],
+        mask: Bool[Array, "seq_len seq_len"],
+    ) -> Float[Array, "seq_len d_model"]:
+        # First compute the queries.
+        q = jax.vmap(self.project_q)(q)
+
+        # Generate the projection matrices for k and v parameterized by q.
+        project_v = jax.vmap(self.hyper_v)(q)
+        project_k = jax.vmap(self.hyper_k)(q)
+        project_v = rearrange(project_v, "s (d d) -> s d d")  # Shape of [q_seq, d_model, d_model].
+        project_k = rearrange(project_k, "s (d d) -> s d d")
+
+        # Compute k and v using the parameterized projections.
+        k = jnp.einsum("ijk,lk->ilj", project_k, k)  # Shape of [q_seq, kv_seq, d_model].
+        v = jnp.einsum("ijk,lk->ilj", project_v, v)
+
+        # Separate heads.
+        q_heads = rearrange(q, "s (n d) -> n s d", n=self.num_heads)
+        k_heads = rearrange(k, "s1 s2 (n d) -> n s1 s2 d", n=self.num_heads)
+        v_heads = rearrange(v, "s1 s2 (n d) -> n s1 s2 d", n=self.num_heads)
+
+        # Finally compute cubic attention.
+        qkv_cubic_attention_heads = jax.vmap(qkv_cubic_attention, in_axes=(0, 0, 0, None))
+        attn_result = qkv_cubic_attention_heads(q_heads, k_heads, v_heads, mask)
         attn_result = rearrange(attn_result, "n s d -> s (n d)")
         return attn_result

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from wandb.wandb_run import Run
 
 from .datasets import ShakespearDataset
-from .model import DecoderOnlyTransformer
+from .model import DecoderTransformer
 
 
 def loader(dataset: Iterable, batch_size: int, n_iters: int, key: random.PRNGKey):
@@ -72,7 +72,7 @@ def batch_metrics(
 
 
 def eval(
-    model: DecoderOnlyTransformer,
+    model: DecoderTransformer,
     dataset: ShakespearDataset,
     batch_size: int,
     n_iters: int,
@@ -100,7 +100,7 @@ def eval(
 
 
 def train(
-    model: DecoderOnlyTransformer,
+    model: DecoderTransformer,
     dataset: ShakespearDataset,
     n_iters: int,
     batch_size: int,


### PR DESCRIPTION
I have a satisfactory implementation of my original idea here. Turns out this is not of cubic complexity so I should rename things to something different such as "Selective attention" or something.

The general idea is to generate the queries first, and then every query and key/value is matched before projecting everything into the final key and value attention vectors.